### PR TITLE
Dynamic journey building

### DIFF
--- a/app/controllers/admin/generated_journeys_controller.rb
+++ b/app/controllers/admin/generated_journeys_controller.rb
@@ -14,7 +14,7 @@ class Admin::GeneratedJourneysController < AdminController
       vehicle_id: generated_journey_params[:vehicle_id],
       start_time: (generated_journey_params[:start_time] || @generated_journey.start_time),
       open_to_bookings: generated_journey_params[:open_to_bookings],
-      reversed: @generated_journey.bookings.first.reversed?,
+      reversed: @generated_journey.reversed?,
       bookings: @generated_journey.bookings
     )
     redirect_to admin_root_path

--- a/app/controllers/admin/generated_journeys_controller.rb
+++ b/app/controllers/admin/generated_journeys_controller.rb
@@ -1,0 +1,33 @@
+class Admin::GeneratedJourneysController < AdminController
+  before_filter :get_journey, only: [:edit, :approve]
+
+  def index
+    @generated_journeys = current_team.generated_journeys
+  end
+  
+  def edit
+  end
+  
+  def approve
+    journey = current_supplier.journeys.create(
+      route: @generated_journey.route,
+      vehicle_id: generated_journey_params[:vehicle_id],
+      start_time: (generated_journey_params[:start_time] || @generated_journey.start_time),
+      open_to_bookings: generated_journey_params[:open_to_bookings],
+      reversed: @generated_journey.bookings.first.reversed?,
+      bookings: @generated_journey.bookings
+    )
+    redirect_to admin_root_path
+  end
+  
+  private
+  
+    def get_journey
+      @generated_journey = GeneratedJourney.find(params[:id])
+    end
+    
+    def generated_journey_params
+      params.require(:generated_journey).permit(:vehicle_id, :start_time, :open_to_bookings)
+    end
+
+end

--- a/app/controllers/admin/generated_journeys_controller.rb
+++ b/app/controllers/admin/generated_journeys_controller.rb
@@ -9,14 +9,11 @@ class Admin::GeneratedJourneysController < AdminController
   end
   
   def approve
-    journey = current_supplier.journeys.create(
-      route: @generated_journey.route,
-      vehicle_id: generated_journey_params[:vehicle_id],
-      start_time: (generated_journey_params[:start_time] || @generated_journey.start_time),
-      open_to_bookings: generated_journey_params[:open_to_bookings],
-      reversed: @generated_journey.reversed?,
-      bookings: @generated_journey.bookings
-    )
+    vehicle = Vehicle.find(generated_journey_params[:vehicle_id])
+    @generated_journey.approve(current_supplier, vehicle, {
+      start_time: generated_journey_params[:start_time],
+      open_to_bookings: generated_journey_params[:open_to_bookings]
+    })
     redirect_to admin_root_path
   end
   

--- a/app/controllers/suggested_journey_controller.rb
+++ b/app/controllers/suggested_journey_controller.rb
@@ -8,7 +8,7 @@ class SuggestedJourneyController < PublicController
   end
   
   def create
-    @suggested_journey = SuggestedJourney.create!(suggested_journey_params)
+    @suggested_journey = @booking.create_suggested_journey(suggested_journey_params)
     redirect_to @back_path
   end
   

--- a/app/jobs/run_dispatcher.rb
+++ b/app/jobs/run_dispatcher.rb
@@ -1,0 +1,15 @@
+class RunDispatcher < Que::Job
+  
+  def run(suggested_journey_id)
+    begin
+      suggested_journey = SuggestedJourney.find(suggested_journey_id)
+      ActiveRecord::Base.transaction do
+        Dispatcher.new(suggested_journey).perform!
+        destroy
+      end
+    rescue ActiveRecord::RecordNotFound
+      destroy
+    end
+  end
+  
+end

--- a/app/mailers/supplier_mailer.rb
+++ b/app/mailers/supplier_mailer.rb
@@ -5,4 +5,10 @@ class SupplierMailer < ApplicationMailer
     @supplier = supplier
     mail(to: @supplier.email, subject: 'You have been approved')
   end
+  
+  def journey_email(suppliers, journey, vehicles)
+    @journey = journey
+    @vehicles = vehicles
+    mail(to: suppliers.map(&:email), subject: 'A journey is available for approval')
+  end
 end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -5,7 +5,8 @@ class Booking < ActiveRecord::Base
   belongs_to :dropoff_stop, class_name: 'Stop'
   belongs_to :passenger
   belongs_to :promo_code
-
+  has_one :suggested_journey
+  
   scope :booked, -> { where(state: 'booked') }
   
   after_destroy :remove_alerts, :set_journey_booked_status

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -48,7 +48,7 @@ class Booking < ActiveRecord::Base
   def reversed?
     pickup_stop.position > dropoff_stop.position
   end
-
+  
   def set_promo_code(code)
     self.promo_code = PromoCode.find_by_code(code)
   end

--- a/app/models/generated_journey.rb
+++ b/app/models/generated_journey.rb
@@ -4,6 +4,15 @@ class GeneratedJourney < ActiveRecord::Base
   has_and_belongs_to_many :vehicles
   has_many :teams, through: :vehicles
   
+  
+  def vehicles_by_team
+    vehicles.group_by(&:team)
+  end
+  
+  def vehicles_for_team(team)
+    vehicles_by_team[team]
+  end
+  
   def reversed?
     bookings.first.reversed?
   end

--- a/app/models/generated_journey.rb
+++ b/app/models/generated_journey.rb
@@ -27,6 +27,7 @@ class GeneratedJourney < ActiveRecord::Base
       reversed: reversed?,
       bookings: bookings
     )
+    notify_passengers(bookings)
     destroy
     journey
   end
@@ -36,6 +37,12 @@ class GeneratedJourney < ActiveRecord::Base
     def send_notification!
       teams.uniq.each do |t|
         SupplierMailer.journey_email(t.suppliers, self, vehicles_for_team(t)).deliver_now
+      end
+    end
+    
+    def notify_passengers(bookings)
+      bookings.each do |booking|
+        SendSMS.enqueue(to: booking.phone_number, template: :generated_journey, booking: booking.id)
       end
     end
   

--- a/app/models/generated_journey.rb
+++ b/app/models/generated_journey.rb
@@ -18,6 +18,19 @@ class GeneratedJourney < ActiveRecord::Base
     bookings.first.reversed?
   end
   
+  def approve(supplier, vehicle, options = {})
+    journey = supplier.journeys.create(
+      route: route,
+      vehicle: vehicle,
+      start_time: (options[:start_time] || start_time),
+      open_to_bookings: options[:open_to_bookings],
+      reversed: reversed?,
+      bookings: bookings
+    )
+    destroy
+    journey
+  end
+  
   private
   
     def send_notification!

--- a/app/models/generated_journey.rb
+++ b/app/models/generated_journey.rb
@@ -3,4 +3,8 @@ class GeneratedJourney < ActiveRecord::Base
   has_many :bookings
   has_and_belongs_to_many :vehicles
   has_many :teams, through: :vehicles
+  
+  def reversed?
+    bookings.first.reversed?
+  end
 end

--- a/app/models/generated_journey.rb
+++ b/app/models/generated_journey.rb
@@ -4,6 +4,7 @@ class GeneratedJourney < ActiveRecord::Base
   has_and_belongs_to_many :vehicles
   has_many :teams, through: :vehicles
   
+  after_create :send_notification!
   
   def vehicles_by_team
     vehicles.group_by(&:team)
@@ -16,4 +17,13 @@ class GeneratedJourney < ActiveRecord::Base
   def reversed?
     bookings.first.reversed?
   end
+  
+  private
+  
+    def send_notification!
+      teams.uniq.each do |t|
+        SupplierMailer.journey_email(t.suppliers, self, vehicles_for_team(t)).deliver_now
+      end
+    end
+  
 end

--- a/app/models/generated_journey.rb
+++ b/app/models/generated_journey.rb
@@ -1,0 +1,6 @@
+class GeneratedJourney < ActiveRecord::Base
+  belongs_to :route
+  has_many :bookings
+  has_and_belongs_to_many :vehicles
+  has_many :teams, through: :vehicles
+end

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -6,8 +6,8 @@ class Journey < ActiveRecord::Base
   has_many :bookings, dependent: :destroy, class_name: 'Booking'
   belongs_to :vehicle
   belongs_to :supplier
-  validates_presence_of :vehicle, :supplier, :start_time, :route
-
+  validates_presence_of :start_time, :route, :vehicle, :supplier
+  
   scope :forwards, -> {where("reversed IS NOT TRUE")}
   scope :backwards, -> {where("reversed IS TRUE")}
   scope :available, -> {where('start_time > ? AND open_to_bookings IS TRUE', Time.now)}

--- a/app/models/suggested_journey.rb
+++ b/app/models/suggested_journey.rb
@@ -2,4 +2,13 @@ class SuggestedJourney < ActiveRecord::Base
   belongs_to :passenger
   belongs_to :route
   belongs_to :booking
+  
+  after_create :run_dispatcher
+  
+  private
+    
+    def run_dispatcher
+      RunDispatcher.enqueue(id)
+    end
+    
 end

--- a/app/models/suggested_journey.rb
+++ b/app/models/suggested_journey.rb
@@ -1,4 +1,5 @@
 class SuggestedJourney < ActiveRecord::Base
   belongs_to :passenger
   belongs_to :route
+  belongs_to :booking
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,6 +2,7 @@ class Team < ActiveRecord::Base
   has_many :suppliers
   has_many :vehicles
   has_many :journeys, through: :suppliers
+  has_many :generated_journeys, through: :vehicles
 
   def name
     if attributes[:name].blank?
@@ -21,5 +22,9 @@ class Team < ActiveRecord::Base
 
   def single_vehicle?
     vehicles.count < 2
+  end
+  
+  def generated_journeys
+    super.order(:id).uniq
   end
 end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -2,7 +2,7 @@ class Vehicle < ActiveRecord::Base
   belongs_to :team
   has_many :journeys, dependent: :destroy
   validates_presence_of :team, :seats, :registration
-
+  has_and_belongs_to_many :generated_journeys
 
   has_attached_file :photo, styles: {
     thumb: '100x100>',

--- a/app/services/sms_service.rb
+++ b/app/services/sms_service.rb
@@ -61,5 +61,17 @@ class SmsService
         #{@booking.pickup_time.strftime("%I:%M %p")}
       """.squish
     end
+    
+    def generated_journey
+      """
+        Good news! We've managed to find a vehicle for your journey from
+        #{@booking.pickup_stop.name} to #{@booking.dropoff_stop.name} on
+        #{friendly_date(@booking.journey.start_time)}. The rough time for your
+        pickup will be #{@booking.pickup_time.strftime("%I:%M %p")}.
+        
+        To confirm and pay for your booking, please go to
+        #{edit_pickup_location_route_booking_url(@booking.route, @booking)}.
+      """.squish
+    end
   
 end

--- a/app/views/admin/generated_journeys/edit.html.erb
+++ b/app/views/admin/generated_journeys/edit.html.erb
@@ -1,0 +1,28 @@
+<div class="container">
+  <div class="inner">
+    <div class="card">
+      <table>
+        <tr>
+          <th>Email</th>
+          <th>Name</th>
+          <th>Phone Number</th>
+          <th>Team</th>
+          <th>Approved?</th>
+          <th>Super admin?</th>
+          <th></th>
+        </tr>
+        <% @suppliers.each do |supplier| %>
+          <tr>
+            <td><%= supplier.email %></td>
+            <td><%= supplier.name %></td>
+            <td><%= supplier.phone_number %></td>
+            <td><%= supplier.team.name %></td>
+            <td><%= supplier.approved? %></td>
+            <td><%= supplier.admin? %></td>
+            <td><%= link_to "edit", edit_admin_supplier_path(supplier) %></td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/generated_journeys/edit.html.erb
+++ b/app/views/admin/generated_journeys/edit.html.erb
@@ -1,28 +1,27 @@
 <div class="container">
   <div class="inner">
-    <div class="card">
-      <table>
-        <tr>
-          <th>Email</th>
-          <th>Name</th>
-          <th>Phone Number</th>
-          <th>Team</th>
-          <th>Approved?</th>
-          <th>Super admin?</th>
-          <th></th>
-        </tr>
-        <% @suppliers.each do |supplier| %>
-          <tr>
-            <td><%= supplier.email %></td>
-            <td><%= supplier.name %></td>
-            <td><%= supplier.phone_number %></td>
-            <td><%= supplier.team.name %></td>
-            <td><%= supplier.approved? %></td>
-            <td><%= supplier.admin? %></td>
-            <td><%= link_to "edit", edit_admin_supplier_path(supplier) %></td>
-          </tr>
-        <% end %>
-      </table>
+    <div class="card no-click wide-btn">
+      <%= form_tag approve_admin_generated_journey_path(@generated_journey), method: :put do %>
+        <div class="inner">
+          <h4>Review / Edit Generated Journey</h4>
+          <%= label_tag :generated_journey_start_time, "Start Date / Time" %>
+          <%= text_field :generated_journey, :start_time, value: @generated_journey.start_time.strftime("%d/%m/%Y %H:%M") %>
+          
+          <%= label_tag :generated_journey_vehicle, "Choose Vehicle" %>
+          <%= select_tag "generated_journey[vehicle_id]", options_for_select(@generated_journey.vehicles_for_team(current_team).collect { |v|
+            [ "#{v.make_model} - #{v.registration}", v.id ]
+          }), { include_blank: true } %>
+        </div>
+        <%= submit_tag "Approve", :class => "button border-bottom-left-radius border-bottom-right-radius"  %>
+      <% end %>
     </div>
   </div>
 </div>
+
+<% content_for :js do %>
+<script type="text/javascript">
+  $('#generated_journey_start_time').datetimepicker({
+    format:'d/m/Y H:i'
+  });
+</script>
+<% end %>

--- a/app/views/admin/generated_journeys/index.html.erb
+++ b/app/views/admin/generated_journeys/index.html.erb
@@ -1,0 +1,20 @@
+<div class="container">
+  <div class="inner">
+    <div class="card">
+      <table>
+        <tr>
+          <th>Route</th>
+          <th>Start Date / Time</th>
+          <th></th>
+        </tr>
+        <% @generated_journeys.each do |journey| %>
+          <tr>
+            <td><%= journey.reversed? ? journey.route.backwards_name : journey.route.forwards_name %></td>
+            <td><%= journey.start_time %></td>
+            <td><%= link_to 'Review / Edit', edit_admin_generated_journey_path(journey) %></td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/supplier_mailer/journey_email.html.erb
+++ b/app/views/supplier_mailer/journey_email.html.erb
@@ -1,0 +1,25 @@
+<h1>A journey is available for approval</h1>
+
+<p>Hi,</p>
+
+<p>
+  Enough people have signed up for pickups to be able to run a journey on the
+  <%= @journey.reversed? ? @journey.route.backwards_name : @journey.route.forwards_name %> route, starting
+  at <%= @journey.start_time.strftime('%A %e %B') %> at <%= @journey.start_time.strftime('%l:%M%P') %>
+</p>
+
+<p>
+  According to the system the following vehicles have enough capacity to run a service:
+</p>
+
+<ul>
+  <% @vehicles.each do |vehicle| %>
+    <li><%= vehicle.make_model %> - <%= vehicle.registration %></li>
+  <% end %>
+</ul>
+
+<p>
+  To view the journey and approve / decline it, access the Pickup admin panel via the link below:
+</p>
+
+<p><%= edit_admin_generated_journey_url(@journey) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,11 @@ Rails.application.routes.draw do
     resources :supplier_suggestions
     resources :promo_codes
     resources :bookings, only: :show
+    resources :generated_journeys, only: [:index, :edit] do
+      member do
+        put :approve
+      end
+    end
   end
   get '/admin' => 'admin/journeys#index', as: :supplier_root # creates user_root_path
 

--- a/db/migrate/20170726154635_add_booking_to_suggested_journey.rb
+++ b/db/migrate/20170726154635_add_booking_to_suggested_journey.rb
@@ -1,0 +1,5 @@
+class AddBookingToSuggestedJourney < ActiveRecord::Migration
+  def change
+    add_reference :suggested_journeys, :booking, index: true
+  end
+end

--- a/db/migrate/20170727154644_create_generated_journeys.rb
+++ b/db/migrate/20170727154644_create_generated_journeys.rb
@@ -1,0 +1,18 @@
+class CreateGeneratedJourneys < ActiveRecord::Migration
+  def change
+    create_table :generated_journeys do |t|
+      t.references :route, index: true, foreign_key: true
+      t.datetime :start_time
+      t.references :bookings, index: true
+      
+      t.timestamps null: false
+    end
+    
+    add_reference :bookings, :generated_journey, index: true
+        
+    create_table :generated_journeys_vehicles, id: false do |t|
+      t.belongs_to :generated_journey, index: true
+      t.belongs_to :vehicle, index: true
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -392,7 +392,8 @@ CREATE TABLE suggested_journeys (
     start_time timestamp without time zone,
     description text,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    booking_id integer
 );
 
 
@@ -924,6 +925,13 @@ CREATE INDEX index_suggested_edit_to_stops_on_stop_id ON suggested_edit_to_stops
 
 
 --
+-- Name: index_suggested_journeys_on_booking_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_suggested_journeys_on_booking_id ON suggested_journeys USING btree (booking_id);
+
+
+--
 -- Name: index_suggested_journeys_on_passenger_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1230,4 +1238,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170712092230');
 INSERT INTO schema_migrations (version) VALUES ('20170712111051');
 
 INSERT INTO schema_migrations (version) VALUES ('20170718094200');
+
+INSERT INTO schema_migrations (version) VALUES ('20170726154635');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -63,7 +63,8 @@ CREATE TABLE bookings (
     scholar_bus_passes integer DEFAULT 0,
     promo_code_id integer,
     passenger_name character varying,
-    payment_method character varying DEFAULT 'cash'::character varying
+    payment_method character varying DEFAULT 'cash'::character varying,
+    generated_journey_id integer
 );
 
 
@@ -84,6 +85,49 @@ CREATE SEQUENCE bookings_id_seq
 --
 
 ALTER SEQUENCE bookings_id_seq OWNED BY bookings.id;
+
+
+--
+-- Name: generated_journeys; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE generated_journeys (
+    id integer NOT NULL,
+    route_id integer,
+    start_time timestamp without time zone,
+    bookings_id integer,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: generated_journeys_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE generated_journeys_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: generated_journeys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE generated_journeys_id_seq OWNED BY generated_journeys.id;
+
+
+--
+-- Name: generated_journeys_vehicles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE generated_journeys_vehicles (
+    generated_journey_id integer,
+    vehicle_id integer
+);
 
 
 --
@@ -609,6 +653,13 @@ ALTER TABLE ONLY bookings ALTER COLUMN id SET DEFAULT nextval('bookings_id_seq':
 
 
 --
+-- Name: generated_journeys id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY generated_journeys ALTER COLUMN id SET DEFAULT nextval('generated_journeys_id_seq'::regclass);
+
+
+--
 -- Name: journeys id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -712,6 +763,14 @@ ALTER TABLE ONLY vehicles ALTER COLUMN id SET DEFAULT nextval('vehicles_id_seq':
 
 ALTER TABLE ONLY bookings
     ADD CONSTRAINT bookings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: generated_journeys generated_journeys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY generated_journeys
+    ADD CONSTRAINT generated_journeys_pkey PRIMARY KEY (id);
 
 
 --
@@ -834,6 +893,13 @@ CREATE INDEX index_bookings_on_dropoff_stop_id ON bookings USING btree (dropoff_
 
 
 --
+-- Name: index_bookings_on_generated_journey_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bookings_on_generated_journey_id ON bookings USING btree (generated_journey_id);
+
+
+--
 -- Name: index_bookings_on_journey_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -859,6 +925,34 @@ CREATE INDEX index_bookings_on_pickup_stop_id ON bookings USING btree (pickup_st
 --
 
 CREATE INDEX index_bookings_on_promo_code_id ON bookings USING btree (promo_code_id);
+
+
+--
+-- Name: index_generated_journeys_on_bookings_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_generated_journeys_on_bookings_id ON generated_journeys USING btree (bookings_id);
+
+
+--
+-- Name: index_generated_journeys_on_route_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_generated_journeys_on_route_id ON generated_journeys USING btree (route_id);
+
+
+--
+-- Name: index_generated_journeys_vehicles_on_generated_journey_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_generated_journeys_vehicles_on_generated_journey_id ON generated_journeys_vehicles USING btree (generated_journey_id);
+
+
+--
+-- Name: index_generated_journeys_vehicles_on_vehicle_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_generated_journeys_vehicles_on_vehicle_id ON generated_journeys_vehicles USING btree (vehicle_id);
 
 
 --
@@ -1082,6 +1176,14 @@ ALTER TABLE ONLY landmarks
 
 
 --
+-- Name: generated_journeys fk_rails_85a068b9d0; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY generated_journeys
+    ADD CONSTRAINT fk_rails_85a068b9d0 FOREIGN KEY (route_id) REFERENCES routes(id);
+
+
+--
 -- Name: vehicles fk_rails_8b6303dec0; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1240,4 +1342,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170712111051');
 INSERT INTO schema_migrations (version) VALUES ('20170718094200');
 
 INSERT INTO schema_migrations (version) VALUES ('20170726154635');
+
+INSERT INTO schema_migrations (version) VALUES ('20170727154644');
 

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -1,0 +1,56 @@
+class Dispatcher
+  
+  def initialize(suggested_journey)
+    @suggested_journey = suggested_journey
+    @from = suggested_journey.start_time
+    @booking = suggested_journey.booking
+    @pickup_stop = @booking.pickup_stop
+    @dropoff_stop = @booking.dropoff_stop
+    @route = @suggested_journey.route
+  end
+  
+  def perform!
+    if suggested_journeys && possible_vehicles
+      GeneratedJourney.create(
+        route: @route,
+        start_time: start_time,
+        booking_ids: booking_ids_for_journeys(suggested_journeys),
+        vehicles: possible_vehicles
+      )
+    end
+  end
+  
+  private
+  
+    def possible_teams
+      possible_vehicles.map { |v| v.team }.flatten.uniq
+    end
+    
+    def possible_vehicles
+      passengers = suggested_journeys.map { |j| j.booking.number_of_passengers }.sum
+      Vehicle.where('seats >= ?', passengers).select { |v| potential_occupancy(passengers, v.seats) > 0.8 }
+    end
+  
+    def booking_ids_for_journeys(journeys)
+      journeys.map { |j| j.booking_id }
+    end
+  
+    def potential_occupancy(seats, passengers)
+      (seats.to_f / passengers.to_f)
+    end
+    
+    def start_time
+      sorted_journeys.first.start_time
+    end
+    
+    def sorted_journeys
+      suggested_journeys.sort_by { |j| j.booking.pickup_stop.position }
+    end
+    
+    def suggested_journeys
+      @suggested_journeys ||= SuggestedJourney.where(route: @route)
+        .where('start_time BETWEEN ? AND ?', @from - 1.hour, @from + 1.hour)
+        .select { |j| j.booking.reversed? == @suggested_journey.booking.reversed? }
+    end
+  
+end

--- a/spec/controllers/admin/generated_journey_controller_spec.rb
+++ b/spec/controllers/admin/generated_journey_controller_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe Admin::GeneratedJourneysController, type: :controller do
+  login_supplier
+  
+  let(:team_1) { FactoryGirl.create(:team, suppliers: [@supplier]) }
+  let(:team_2) { FactoryGirl.create(:team) }
+  
+  let(:team_1_vehicle_1) { FactoryGirl.create(:vehicle, seats: 4, team: team_1) }
+  let(:team_1_vehicle_2) { FactoryGirl.create(:vehicle, seats: 4, team: team_1) }
+  let(:team_2_vehicle) { FactoryGirl.create(:vehicle, seats: 4, team: team_2) }
+  
+  describe '#index' do
+
+    let!(:team_journeys) {
+      FactoryGirl.create_list(:generated_journey, 4, vehicles: [team_1_vehicle_1]) +
+      FactoryGirl.create_list(:generated_journey, 3, vehicles: [team_1_vehicle_2, team_2_vehicle]) +
+      FactoryGirl.create_list(:generated_journey, 2, vehicles: [team_1_vehicle_1, team_1_vehicle_2])
+    }
+    
+    let!(:other_journeys) { FactoryGirl.create_list(:generated_journey, 4, vehicles: [team_2_vehicle]) }
+    
+    it 'lists generated journeys for a team' do
+      get :index
+      expect(assigns(:generated_journeys).to_a).to eq(team_journeys)
+    end
+    
+  end
+  
+  describe '#edit' do
+    
+    let(:generated_journey) { FactoryGirl.create(:generated_journey, vehicles: [team_1_vehicle_1]) }
+    
+    it 'shows a journey' do
+      get :edit, { id: generated_journey.id }
+      expect(assigns(:generated_journey)).to eq(generated_journey)
+    end
+    
+  end
+  
+  describe '#approve' do
+    
+    let(:route) { FactoryGirl.create(:route) }
+    let(:bookings) {
+      FactoryGirl.create_list(:booking, 5,
+        journey: nil,
+        pickup_stop: route.stops[0],
+        dropoff_stop: route.stops[3]
+      )
+    }
+    let(:generated_journey) {
+      FactoryGirl.create(:generated_journey,
+        vehicles: [team_1_vehicle_1, team_1_vehicle_2],
+        bookings: bookings,
+        route: route
+      )
+    }
+    let(:subject) {
+      put :approve, {
+        id: generated_journey.id,
+        generated_journey: {
+          vehicle_id: team_1_vehicle_1.id,
+        }
+      }
+    }
+    
+    it 'creates a journey' do
+      expect { subject }.to change { Journey.count }.by(1)
+    end
+    
+    it 'creates a journey with the correct things' do
+      subject
+      journey = Journey.last
+      expect(journey.vehicle).to eq(team_1_vehicle_1)
+      expect(journey.start_time).to eq(generated_journey.start_time)
+      expect(journey.bookings).to eq(bookings)
+      expect(journey.reversed?).to eq(false)
+    end
+    
+    context 'for reversed bookings' do
+      
+      let(:bookings) {
+        FactoryGirl.create_list(:booking, 5,
+          journey: nil,
+          pickup_stop: route.stops[3],
+          dropoff_stop: route.stops[0]
+        )
+      }
+      
+      it 'sets journey to reversed' do
+        subject
+        journey = Journey.last
+        expect(journey.reversed?).to eq(true)
+      end
+      
+    end
+    
+  end
+
+end

--- a/spec/controllers/admin/generated_journey_controller_spec.rb
+++ b/spec/controllers/admin/generated_journey_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Admin::GeneratedJourneysController, type: :controller do
       subject
       journey = Journey.last
       expect(journey.vehicle).to eq(team_1_vehicle_1)
-      expect(journey.start_time).to eq(generated_journey.start_time)
+      expect(journey.start_time.to_s).to eq(generated_journey.start_time.to_s)
       expect(journey.bookings).to eq(bookings)
       expect(journey.reversed?).to eq(false)
     end

--- a/spec/factories/generated_journey.rb
+++ b/spec/factories/generated_journey.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory(:generated_journey) do
+    start_time DateTime.now
+  end
+end

--- a/spec/factories/generated_journey.rb
+++ b/spec/factories/generated_journey.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   factory(:generated_journey) do
     start_time DateTime.now
+    route { FactoryGirl.create(:route) }
+    bookings { FactoryGirl.create_list(:booking, 5) }
   end
 end

--- a/spec/factories/suggested_journey.rb
+++ b/spec/factories/suggested_journey.rb
@@ -4,5 +4,21 @@ FactoryGirl.define do
     passenger
     route
     start_time "2016-08-11T13:52 UTC"
+    booking
+    
+    # We don't want the Dispatcher to actually run after create in tests, but
+    # this is a nicer solution than removing callbacks
+    before(:create) do
+      double = instance_double("Dispatcher")
+      allow(Dispatcher).to receive(:new) {
+        allow(double).to receive(:perform!)
+        double
+      }
+    end
+    
+    # Once the callback has been fired, we reset the stub
+    after(:create) do
+      allow(Dispatcher).to receive(:new).and_call_original
+    end
   end
 end

--- a/spec/factories/supplier.rb
+++ b/spec/factories/supplier.rb
@@ -1,17 +1,11 @@
 FactoryGirl.define do
-  sequence :email do |n|
-    "person#{n}@example.com"
-  end
-end
-
-FactoryGirl.define do
   factory(:supplier) do
     admin false
     approved false
-    email
+    sequence(:email) { |n| "person#{n}@example.com" }
     password "password"
     password_confirmation "password"
-    name "James Darling"
+    sequence(:name) { |n| "Supplier #{n}" }
     phone_number "07811407085"
   end
 end

--- a/spec/factories/team.rb
+++ b/spec/factories/team.rb
@@ -1,5 +1,9 @@
 FactoryGirl.define do
   factory(:team) do
     name nil
+    transient { suppliers_count 1 }
+    after(:create) do |team, evaluator|
+      create_list(:supplier, evaluator.suppliers_count, team: team)
+    end
   end
 end

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe Dispatcher, type: :model do
+
+  let(:route) do
+    FactoryGirl.create(:route, stops: [
+        FactoryGirl.create(:stop, name: 'Bradwell', minutes_from_last_stop: 0, position: 1),
+        FactoryGirl.create(:stop, name: 'Tillingham', minutes_from_last_stop: 5, position: 2),
+        FactoryGirl.create(:stop, name: 'Asheldham', minutes_from_last_stop: 10, position: 3),
+        FactoryGirl.create(:stop, name: 'Southminster', minutes_from_last_stop: 7, position: 4),
+        FactoryGirl.create(:stop, name: 'Burnham-On-Crouch', minutes_from_last_stop: 13, position: 5),
+        FactoryGirl.create(:stop, name: 'Dengie', minutes_from_last_stop: 6, position: 6)
+    ])
+  end
+  
+  let(:suggested_journey) do
+    FactoryGirl.create(:suggested_journey,
+      route: route,
+      start_time: DateTime.parse('2017-01-01T10:00:00'),
+      booking: FactoryGirl.create(:booking, pickup_stop: route.stops[0], dropoff_stop: route.stops[3], journey: nil)
+    )
+  end
+  
+  context 'with a successful match' do
+    
+    let(:dispatcher) { Dispatcher.new(suggested_journey) }
+    
+    before do
+      # Create some suggested journeys
+      FactoryGirl.create(:suggested_journey,
+        route: route,
+        start_time: DateTime.parse('2017-01-01T10:20:00'),
+        booking: FactoryGirl.create(:booking, pickup_stop: route.stops[3], dropoff_stop: route.stops[5], journey: nil)
+      )
+      FactoryGirl.create(:suggested_journey,
+        route: route,
+        start_time: DateTime.parse('2017-01-01T09:30:00'),
+        booking: FactoryGirl.create(:booking, pickup_stop: route.stops[1], dropoff_stop: route.stops[4], journey: nil)
+      )
+      FactoryGirl.create(:suggested_journey,
+        route: route,
+        start_time: DateTime.parse('2017-01-01T10:30:00'),
+        booking: FactoryGirl.create(:booking, pickup_stop: route.stops[2], dropoff_stop: route.stops[3], journey: nil)
+      )
+      FactoryGirl.create(:suggested_journey,
+        route: route,
+        start_time: DateTime.parse('2017-01-01T09:40:00'),
+        booking: FactoryGirl.create(:booking, pickup_stop: route.stops[2], dropoff_stop: route.stops[5], journey: nil, number_of_passengers: 2)
+      )
+      # Same route, reversed
+      FactoryGirl.create(:suggested_journey,
+        route: route,
+        start_time: DateTime.parse('2017-01-01T09:40:00'),
+        booking: FactoryGirl.create(:booking, pickup_stop: route.stops[5], dropoff_stop: route.stops[2], journey: nil, number_of_passengers: 2)
+      )
+      # Same route, different day
+      FactoryGirl.create(:suggested_journey,
+        route: route,
+        start_time: DateTime.parse('2017-01-01T17:00:00'),
+        booking: FactoryGirl.create(:booking, pickup_stop: route.stops[2], journey: nil)
+      )
+      # Different route, same time
+      FactoryGirl.create(:suggested_journey,
+        route: FactoryGirl.create(:route),
+        start_time: DateTime.parse('2017-01-01T10:00:00'),
+        booking: FactoryGirl.create(:booking, pickup_stop: route.stops[2], journey: nil)
+      )
+      # Same route, different day
+      FactoryGirl.create(:suggested_journey,
+        route: route,
+        start_time: DateTime.parse('2017-01-02T11:00:00'),
+        booking: FactoryGirl.create(:booking, pickup_stop: route.stops[2], journey: nil)
+      )
+      
+      # Create some teams and vehicles
+      team_1 = FactoryGirl.create(:team)
+      team_2 = FactoryGirl.create(:team)
+      
+      FactoryGirl.create(:vehicle, seats: 4, team: team_1)
+      FactoryGirl.create(:vehicle, seats: 4, team: team_2)
+      
+      FactoryGirl.create(:vehicle, seats: 6, team: team_1, make_model: 'Cool Vehicle')
+      FactoryGirl.create(:vehicle, seats: 12, team: team_2, make_model: 'Big Vehicle')
+    end
+    
+    it 'returns suggested journeys' do
+      expect(dispatcher.send(:suggested_journeys).count).to eq(5)
+    end
+    
+    it 'returns possible teams' do
+      expect(dispatcher.send(:possible_teams).count).to eq(1)
+      expect(dispatcher.send(:possible_teams).first.name).to eq('Supplier 1\'s Team')
+    end
+    
+    it 'returns possible vehicles' do
+      expect(dispatcher.send(:possible_vehicles).count).to eq(1)
+      expect(dispatcher.send(:possible_vehicles).first.make_model).to eq('Cool Vehicle')
+    end
+    
+    it 'returns a start time' do
+      expect(dispatcher.send(:start_time)).to eq(DateTime.parse('2017-01-01T10:00:00'))
+    end
+    
+    context '#perform' do
+      
+      let(:journey) { dispatcher.perform! && GeneratedJourney.first }
+      
+      it 'creates a generated journey' do
+        expect(journey.start_time).to eq(DateTime.parse('2017-01-01T10:00:00'))
+        expect(journey.route).to eq(suggested_journey.route)
+      end
+      
+      it 'creates bookings' do
+        expect(journey.bookings.count).to eq(5)
+        bookings = journey.bookings.sort_by { |b| b.pickup_stop }
+        expect(bookings[0].pickup_stop).to eq(suggested_journey.booking.pickup_stop)
+      end
+      
+    end
+    
+  end
+  
+end

--- a/spec/mailers/supplier_mailer_spec.rb
+++ b/spec/mailers/supplier_mailer_spec.rb
@@ -1,4 +1,34 @@
 require "rails_helper"
 
 RSpec.describe SupplierMailer, type: :mailer do
+  
+  context 'journey_email' do
+    let(:suppliers) { FactoryGirl.create_list(:supplier, 4) }
+    let(:vehicles) { FactoryGirl.create_list(:vehicle, 2) }
+    let(:route) {
+      FactoryGirl.create(:route, stops: [
+        FactoryGirl.create(:stop, name: 'First Stop'),
+        FactoryGirl.create(:stop, name: 'Second Stop'),
+        FactoryGirl.create(:stop, name: 'Last Stop')
+      ])
+    }
+    let(:journey) { FactoryGirl.create(:generated_journey, route: route, start_time: DateTime.parse('2017-01-01T09:00:00')) }
+    let(:mail) { described_class.journey_email(suppliers, journey, vehicles).deliver_now }
+    
+    it 'delivers to the right recipients' do
+      expect(mail.to).to eq(suppliers.map(&:email))
+    end
+    
+    it 'has the correct subject' do
+      expect(mail.subject).to eq('A journey is available for approval')
+    end
+    
+    it 'contains the correct information in the body' do
+      expect(mail.body).to match /Last Stop \- First Stop/
+      expect(mail.body).to match /Sunday  1 January/
+      expect(mail.body).to match /9:00am/
+    end
+    
+  end
+  
 end

--- a/spec/models/generated_journey_spec.rb
+++ b/spec/models/generated_journey_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GeneratedJourney, type: :model do
   let(:team_1_vehicles) { FactoryGirl.create_list(:vehicle, 5, team: team_1) }
   let(:team_2_vehicles) { FactoryGirl.create_list(:vehicle, 3, team: team_2) }
 
-  let(:generated_journey) {
+  let!(:generated_journey) {
     FactoryGirl.create(:generated_journey,
       vehicles: team_1_vehicles + team_2_vehicles
     )
@@ -26,6 +26,52 @@ RSpec.describe GeneratedJourney, type: :model do
         vehicles: team_1_vehicles + team_2_vehicles
       )
     }.to change { ActionMailer::Base.deliveries.count }.by(2)
+  end
+  
+  context 'approves a generated journey' do
+    
+    let(:supplier) { team_1.suppliers.first }
+    let(:vehicle) { team_1_vehicles.first }
+    
+    let(:subject) { generated_journey.approve(supplier, vehicle, options) }
+    
+    context 'with no options' do
+      let(:options) { Hash.new }
+      
+      it 'creates a journey' do
+        expect { subject }.to change { Journey.count }.by(1)
+      end
+      
+      it 'creates a journey with the correct parameters' do
+        expect(subject.route).to eq(generated_journey.route)
+        expect(subject.vehicle).to eq(vehicle)
+        expect(subject.route).to eq(generated_journey.route)
+        expect(subject.start_time).to eq(generated_journey.start_time)
+        expect(subject.reversed?).to eq(generated_journey.reversed?)
+        expect(subject.bookings).to eq(generated_journey.bookings)
+      end
+      
+      it 'deletes the generated journey' do
+        expect { subject }.to change { GeneratedJourney.count }.by(-1)
+      end
+    end
+    
+    context 'with options' do
+      
+      let(:options) {
+        {
+          start_time: DateTime.parse('2017-02-03T09:00:00Z'),
+          open_to_bookings: false
+        }
+      }
+      
+      it 'creates a journey with the correct parameters' do
+        expect(subject.start_time.to_s).to eq('2017-02-03 09:00:00 UTC')
+        expect(subject.open_to_bookings).to eq(false)
+      end
+
+    end
+    
   end
   
 end

--- a/spec/models/generated_journey_spec.rb
+++ b/spec/models/generated_journey_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe GeneratedJourney, type: :model do
+  
+  let(:team_1) { FactoryGirl.create(:team, suppliers: FactoryGirl.create_list(:supplier, 2)) }
+  let(:team_2) { FactoryGirl.create(:team, suppliers: FactoryGirl.create_list(:supplier, 3)) }
+  
+  let(:team_1_vehicles) { FactoryGirl.create_list(:vehicle, 5, team: team_1) }
+  let(:team_2_vehicles) { FactoryGirl.create_list(:vehicle, 3, team: team_2) }
+
+  let(:generated_journey) {
+    FactoryGirl.create(:generated_journey,
+      vehicles: team_1_vehicles + team_2_vehicles
+    )
+  }
+  
+  it 'groups vehicles by supplier' do
+    vehicles_by_team = generated_journey.vehicles_by_team
+    expect(vehicles_by_team[team_1].count).to eq(5)
+    expect(vehicles_by_team[team_2].count).to eq(3)
+  end
+  
+  it 'sends an email to all suppliers' do
+    expect {
+      FactoryGirl.create(:generated_journey,
+        vehicles: team_1_vehicles + team_2_vehicles
+      )
+    }.to change { ActionMailer::Base.deliveries.count }.by(2)
+  end
+  
+end

--- a/spec/models/generated_journey_spec.rb
+++ b/spec/models/generated_journey_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe GeneratedJourney, type: :model do
       it 'deletes the generated journey' do
         expect { subject }.to change { GeneratedJourney.count }.by(-1)
       end
+      
+      it 'notifies all the passengers' do
+        expect { subject }.to change { FakeSMS.messages.count }.by(generated_journey.bookings.count)
+      end
     end
     
     context 'with options' do

--- a/spec/models/suggested_journey_spec.rb
+++ b/spec/models/suggested_journey_spec.rb
@@ -1,4 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe SuggestedJourney, type: :model do
+  
+  it 'runs the dispatcher after creation' do
+    expect {
+      FactoryGirl.create(:suggested_journey)
+    }.to change { QueJob.count }.by(1)
+  end
+  
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,10 @@ end
 
 Capybara.javascript_driver = :headless_chrome
 
+FactoryGirl::SyntaxRunner.class_eval do
+  include RSpec::Mocks::ExampleMethods
+end
+
 RSpec.configure do |config|
   config.use_transactional_fixtures = false
 


### PR DESCRIPTION
(Reopened to trigger a new Heroku deploy)

At the moment, pickup requests that aren't on an already built journey go into a black hole. This PR adds a new Dispatcher class that takes all the requested journeys and attempts to find other requests that are on the same route at roughly the same time. Suppliers are then notified, they can then review the journey, apply a vehicle and claim the route. The passengers are then notified and they can complete their booking!