### PR TITLE
Add endpoint to send arbitrary SMS messages

### DIFF
--- a/app/controllers/admin/sms_controller.rb
+++ b/app/controllers/admin/sms_controller.rb
@@ -1,0 +1,22 @@
+class Admin::SmsController < AdminController
+  
+  def new
+  end
+  
+  def create
+    if to = Passenger.formatted_phone_number(sms_params[:to])
+      SendSMS.enqueue(to: to, message: sms_params[:body])
+      redirect_to admin_root_path
+    else
+      @flash_alert = "Phone number is not valid, please try another one"
+      render action: 'new'
+    end
+  end
+  
+  private
+  
+    def sms_params
+      params.require(:sms).permit(:to, :body)
+    end
+  
+end

--- a/app/views/admin/sms/new.html.erb
+++ b/app/views/admin/sms/new.html.erb
@@ -1,0 +1,16 @@
+<div id="sup_new_sms" class="container">
+  <div class="inner">
+    <div class="card no-click">
+      <div class="inner">
+        <h2>Send an SMS:</h2>
+        <%= form_tag admin_sms_path do %>
+          <%= label_tag 'sms[to]', 'To' %>
+          <%= text_field :sms, :to %>
+          <%= label_tag 'sms[body]', 'Body' %>
+          <%= text_area :sms, :body, rows: 5 %>
+      </div>
+      <%= submit_tag "Send SMS", :class => "button name_validation border-bottom-radius" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
     resources :supplier_suggestions
     resources :promo_codes
     resources :bookings, only: :show
+    resources :sms, only: [:new, :create]
   end
   get '/admin' => 'admin/journeys#index', as: :supplier_root # creates user_root_path
 

--- a/spec/controllers/admin/sms_controller_spec.rb
+++ b/spec/controllers/admin/sms_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Admin::SmsController, type: :controller do
+  login_supplier
+  
+  describe 'new' do
+    subject { get :new }
+    
+    it 'renders the correct template' do
+      expect(subject).to render_template('admin/sms/new')
+    end
+  end
+  
+  describe 'create' do
+    let(:params) {
+      {
+        sms: {
+          to: '+15005550006',
+          body: 'Hello there'
+        }
+      }
+    }
+    subject { post :create, params }
+
+    it 'sends an sms' do
+      expect {
+        subject
+      }.to change { FakeSMS.messages.count }.by(1)
+      
+      expect(FakeSMS.messages.last[:to]).to eq(params[:sms][:to])
+      expect(FakeSMS.messages.last[:body]).to eq(params[:sms][:body])
+    end
+    
+    context 'with invalid phone number' do
+      let(:params) {
+        {
+          sms: {
+            to: '3232323232',
+            body: 'Hello there'
+          }
+        }
+      }
+      
+      it 'shows an error' do
+        expect(subject).to render_template('admin/sms/new')
+        expect(assigns(:flash_alert)).to eq('Phone number is not valid, please try another one')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is needed for the initial testing stage with real passengers. This may be thrown away at some point.