### PR TITLE
Add Google Analytics

### DIFF
--- a/app/views/journeys/index.html.erb
+++ b/app/views/journeys/index.html.erb
@@ -14,6 +14,16 @@
 <% content_for :js do %>
 
 <script type='text/javascript'>
+  // Monkey patch pushState to notify Google Analytics
+  var pushState = history.pushState;
+  history.pushState = function () {
+    pushState.apply(history, arguments);
+    if (typeof(ga) == 'function') {
+      ga('set', 'location', event.data.url);
+      ga('send', 'pageview');
+    }
+  };
+  
   var enableTo = (slug) => {
     var toOptions = options;
     $('#from').data('slug', slug);

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -92,4 +92,13 @@
   <!-- <footer class="footer"></footer> -->
 </body>
 <%= yield(:js) %>
+<% if Rails.env.production? && ENV['GA_ANALYTICS_ID'] %>
+  <script type="text/javascript">
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    ga('create', ENV['GA_ANALYTICS_ID'], 'auto');
+  </script>
+<% end %>
 </html>


### PR DESCRIPTION
This is good to merge, but we haven't set up the account yet. Once we do, we can add the env var `GA_ANALYTICS_ID` to the Heroku app and it'll start tracking!