### PR TITLE
Send confirmations to team emails

### DIFF
--- a/app/controllers/admin/teams_controller.rb
+++ b/app/controllers/admin/teams_controller.rb
@@ -1,5 +1,35 @@
 class Admin::TeamsController < AdminController
+  before_filter :check_permissions, except: [:show]
+  before_filter :get_team, only: [:edit, :update]
+  
   def show
     @back_path = admin_root_path
   end
+  
+  def index
+    @teams = Team.all
+  end
+  
+  def edit
+  end
+  
+  def update
+    team_params[:suppliers_attributes].each do |s|
+      supplier = Supplier.find(s[:id])
+      supplier.team = @team
+      supplier.save
+    end
+    @team.update_attributes(team_params)
+    redirect_to admin_teams_url, notice: 'Team updated!'
+  end
+  
+  private
+  
+    def get_team
+      @team = Team.find(params[:id])
+    end
+
+    def team_params
+      params.require(:team).permit(:name, :email, suppliers_attributes: [:id])
+    end
 end

--- a/app/mailers/booking_mailer.rb
+++ b/app/mailers/booking_mailer.rb
@@ -5,12 +5,12 @@ class BookingMailer < ActionMailer::Base
 
   def booking_confirmed(params)
     @booking = Booking.find(params['booking_id'])
-    mail(to: @booking.journey.supplier.email, subject: 'A new booking has been confirmed')
+    mail(to: @booking.journey.supplier.team.email, subject: 'A new booking has been confirmed')
   end
   
   def booking_cancelled(params)
     @booking = Booking.find(params['booking_id'])
-    mail(to: @booking.journey.supplier.email, subject: 'Booking cancelled')
+    mail(to: @booking.journey.supplier.team.email, subject: 'Booking cancelled')
   end
   
   def user_confirmation(params)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -4,6 +4,8 @@ class Team < ActiveRecord::Base
   has_many :journeys, through: :suppliers
   
   after_create :set_name
+  
+  accepts_nested_attributes_for :suppliers
 
   def solo_team?
     suppliers.count < 2

--- a/app/views/admin/teams/_supplier.html.haml
+++ b/app/views/admin/teams/_supplier.html.haml
@@ -1,0 +1,5 @@
+.nested-fields
+  .col-9
+    = f.select :id, Supplier.all.collect {|p| [ p.name, p.id ] }, { include_blank: 'Please select a supplier' }, class: 'select'
+  .col-2
+    = link_to_remove_association 'x', f, class: 'button'

--- a/app/views/admin/teams/edit.html.haml
+++ b/app/views/admin/teams/edit.html.haml
@@ -1,0 +1,24 @@
+.container
+  .inner
+    .card.wide-btn.no-click
+      .inner
+        
+        = form_for [:admin, @team] do |form|
+        
+          = form.label :name
+          = form.text_field :name
+          
+          = form.label :email
+          = form.email_field :email
+          
+          %h3 Suppliers
+            
+          = form.fields_for :suppliers do |supplier|
+            = render 'admin/teams/supplier', f: supplier
+          
+          .links
+            = link_to_add_association 'Add Supplier', form, :suppliers, partial: 'admin/teams/supplier', class: 'button'
+                        
+          %hr
+          
+          = form.submit 'Update', :class => 'button border-left-radius'

--- a/app/views/admin/teams/index.html.erb
+++ b/app/views/admin/teams/index.html.erb
@@ -1,0 +1,20 @@
+<div class="container">
+  <div class="inner">
+    <div class="card">
+      <table>
+        <tr>
+          <th>Name</th>
+          <th>Email</th>
+          <th></th>
+        </tr>
+        <% @teams.each do |team| %>
+          <tr>
+            <td><%= team.name %></td>
+            <td><%= team.email %></td>
+            <td><%= link_to "edit", edit_admin_team_path(team) %></td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/teams/show.html.erb
+++ b/app/views/admin/teams/show.html.erb
@@ -60,6 +60,7 @@
           <h2>Super Admin Options</h2>
           <p><strong>Admin</strong> - <%= link_to "Manage Core Routes", admin_routes_path %></p>
           <p><strong>Admin</strong> - <%= link_to "Manage Suppliers", admin_suppliers_path %></p>
+          <p><strong>Admin</strong> - <%= link_to "Manage Teams", admin_teams_path %></p>
           <p><strong>Admin</strong> - <%= link_to "View Suggestions", admin_suggestions_path %></p>
           <p><strong>Admin</strong> - <%= link_to "Manage Promo Codes", admin_promo_codes_path %></p>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,8 @@ Rails.application.routes.draw do
   namespace :admin do
     get 'pending' => 'suppliers#pending'
     root 'journeys#index'
-    resource :team
+    resource :team, only: [:show]
+    resources :teams
     resources :vehicles
     resources :journeys do
       collection do

--- a/db/migrate/20171120125309_add_email_to_team.rb
+++ b/db/migrate/20171120125309_add_email_to_team.rb
@@ -1,0 +1,5 @@
+class AddEmailToTeam < ActiveRecord::Migration
+  def change
+    add_column :teams, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171113103615) do
+ActiveRecord::Schema.define(version: 20171120125309) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -228,6 +228,7 @@ ActiveRecord::Schema.define(version: 20171113103615) do
     t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "email"
   end
 
   create_table "vehicles", force: :cascade do |t|

--- a/spec/controllers/admin/teams_controller_spec.rb
+++ b/spec/controllers/admin/teams_controller_spec.rb
@@ -1,5 +1,67 @@
 require 'rails_helper'
 
 RSpec.describe Admin::TeamsController, type: :controller do
+  login_supplier(true)
+  
+  let(:team) { FactoryBot.create(:team) }
+
+  describe 'GET index' do
+    
+    let(:teams) { FactoryBot.create_list(:team, 5) }
+    
+    it 'gets all teams' do
+      get :index
+      expect(assigns(:teams)).to eq([@supplier.team] + teams)
+    end
+    
+    context 'when not an admin' do
+      login_supplier
+      
+      it 'returns unauthorized' do
+        get :index
+        expect(response).to have_http_status(401)
+      end
+
+    end
+    
+  end
+  
+  describe 'GET edit' do
+      
+    it 'gets a team' do
+      get :edit, id: team
+      expect(assigns(:team)).to eq(team)
+    end
+    
+  end
+  
+  describe 'PUT update' do
+    
+    let(:suppliers) { FactoryBot.create_list(:supplier, 3) }
+    
+    it 'updates a team' do
+      put :update, id: team, team: {
+        name: 'New name',
+        email: 'foo@example.com',
+        suppliers_attributes: [
+          {
+            id: suppliers[0]
+          },
+          {
+            id: suppliers[1]
+          },
+          {
+            id: suppliers[2]
+          }
+        ]
+      }
+      
+      team.reload
+      expect(team.name).to eq('New name')
+      expect(team.email).to eq('foo@example.com')
+      expect(team.suppliers.count).to eq(3)
+    end
+    
+  end
 
 end

--- a/spec/factories/team.rb
+++ b/spec/factories/team.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory(:team) do
     name nil
+    email 'hello@example.com'
   end
 end

--- a/spec/mailers/booking_mailer_spec.rb
+++ b/spec/mailers/booking_mailer_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe BookingMailer, type: :mailer do
     ]
   }
   let(:route) { FactoryBot.create(:route, stops: stops) }
-  let(:journey) { FactoryBot.create(:journey, route: route, start_time: DateTime.parse('2017-01-01T10:00:00')) }
+  let(:team) { FactoryBot.create(:team, email: 'team@example.com') }
+  let(:supplier) { FactoryBot.create(:supplier, team: team) }
+  let(:journey) { FactoryBot.create(:journey, route: route, start_time: DateTime.parse('2017-01-01T10:00:00'), supplier: supplier) }
   let(:booking) {
     FactoryBot.create(:booking,
       journey: journey,
@@ -49,7 +51,7 @@ RSpec.describe BookingMailer, type: :mailer do
       
       it 'renders the headers' do
         expect(mail.subject).to eq('A new booking has been confirmed')
-        expect(mail.to).to eq([booking.journey.supplier.email])
+        expect(mail.to).to eq(['team@example.com'])
         expect(mail.from).to eq([ENV['RIDE_ADMIN_EMAIL']])
       end
       
@@ -74,7 +76,7 @@ RSpec.describe BookingMailer, type: :mailer do
       
       it 'renders the headers' do
         expect(mail.subject).to eq('Booking cancelled')
-        expect(mail.to).to eq([booking.journey.supplier.email])
+        expect(mail.to).to eq(['team@example.com'])
         expect(mail.from).to eq([ENV['RIDE_ADMIN_EMAIL']])
       end
       


### PR DESCRIPTION
Before, confirmations of bookings and cancellations went to whichever supplier created the journey, which could get unwieldy if there is more than one supplier per team. Now, Teams have a central email address (configurable by an admin), where all confirmation emails go. Admins also have tighter control over team membership and can easily add suppliers to new teams if needs be.