### PR TITLE
Add pricing rule to route

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -97,11 +97,11 @@ class Booking < ActiveRecord::Base
   end
 
   def child_single_price
-    adult_single_price / 2
+    route.pricing_rule['child_single_price'] || (adult_single_price / 2)
   end
 
   def child_return_price
-    child_single_price * 2
+    route.pricing_rule['child_return_price'] || child_single_price * 2
   end
 
   def single_price

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -3,6 +3,8 @@ class Route < ActiveRecord::Base
   has_many :journeys, -> { order(start_time: :asc) }, dependent: :destroy
   has_many :suggested_journeys, dependent: :destroy
   has_many :places, through: :stops
+  
+  after_initialize :set_rule
 
   def self.bookable_routes
     all.reject {|route| route.stops.count <= 2}
@@ -49,4 +51,10 @@ class Route < ActiveRecord::Base
     end
     available_journeys_by_date
   end
+  
+  private
+
+    def set_rule
+      self.pricing_rule ||= {}
+    end
 end

--- a/db/migrate/20171122205040_add_pricing_rule_to_route.rb
+++ b/db/migrate/20171122205040_add_pricing_rule_to_route.rb
@@ -1,0 +1,5 @@
+class AddPricingRuleToRoute < ActiveRecord::Migration
+  def change
+    add_column :routes, :pricing_rule, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171120125309) do
+ActiveRecord::Schema.define(version: 20171122205040) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -138,8 +138,9 @@ ActiveRecord::Schema.define(version: 20171120125309) do
   end
 
   create_table "routes", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.json     "pricing_rule"
   end
 
   create_table "stops", force: :cascade do |t|

--- a/spec/models/booking_spec.rb
+++ b/spec/models/booking_spec.rb
@@ -637,6 +637,17 @@ RSpec.describe Booking, :que, type: :model do
       
     end
     
+    it 'with pricing rules' do
+      booking.route.pricing_rule = {
+        child_single_price: 0,
+        child_return_price: 0
+      }
+      booking.child_tickets = 1
+      
+      expect(booking.price).to eq(0)
+      expect(booking.return_price).to eq(0)
+    end
+    
   end
   
 end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -1,4 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe Route, type: :model do
+  
+  let(:route) { FactoryBot.create(:route) }
+  
+  it 'has a pricing rule' do
+    route.pricing_rule = {
+      child_single_price: 0,
+      child_return_price: 0
+    }
+    route.save
+    expect(route.pricing_rule).to eq({
+      'child_single_price' => 0,
+      'child_return_price' => 0
+    })
+  end
+  
+  it 'returns an empty hash by default' do
+    expect(route.pricing_rule).to eq({})
+  end
+  
 end


### PR DESCRIPTION
This adds a JSON column to a route that allows pricing rules to be set. Currently only settable on the console and by a dev, and only covers child fares, but can potentially be extended into a DSL to carry out more complex rules