### PR TITLE
Limit number of journeys

### DIFF
--- a/app/assets/stylesheets/pages/_bookings-new.scss
+++ b/app/assets/stylesheets/pages/_bookings-new.scss
@@ -1,0 +1,7 @@
+#bookings-new {
+  #show-more {
+    text-align: right;
+    position: relative;
+    top: 7px;
+  }
+}

--- a/app/assets/stylesheets/pages/_import.scss
+++ b/app/assets/stylesheets/pages/_import.scss
@@ -3,6 +3,7 @@
 @import "bookings-cancel";
 @import "bookings-cancelled";
 @import "bookings-confirmation";
+@import "bookings-new";
 @import "bookings-update";
 @import "demo";
 @import "journeys-index";

--- a/app/views/bookings/_days.html.haml
+++ b/app/views/bookings/_days.html.haml
@@ -2,8 +2,8 @@
   %label
     = t('bookings.day.title')
   %section.dates
-    - @journeys.keys.uniq.each do |j|
-      %a.button.single.date-button{ 'data-selector' => "journeys_#{j.to_date}" }
+    - @journeys.keys.uniq.each_with_index do |j, i|
+      %a.button.single.date-button{ 'data-selector' => "journeys_#{j.to_date}", 'class' => i > 7 ? 'hidden' : '' }
         %span.date
           = j.to_date.strftime('%e %b')
         %span.day

--- a/app/views/bookings/_days.html.haml
+++ b/app/views/bookings/_days.html.haml
@@ -8,3 +8,18 @@
           = j.to_date.strftime('%e %b')
         %span.day
           = j.to_date.strftime('%a')
+  
+  - if @journeys.keys.uniq.count > 7
+    %p#show-more
+      %a{ href: '#' }
+        Show more
+
+:javascript
+  
+  $('#show-more a').click(function() {
+    $('.date-button.hidden').slice(0,7).removeClass('hidden');
+    if ($('.date-button.hidden').length == 0) {
+      $(this).addClass('hidden');
+    }
+    scrollToBottom();
+  });


### PR DESCRIPTION
Duplicating a bunch of journeys means that they all show on one page. I've added some very basic frontend pagination to combat this. There's probably a more elegant way to do this, but this works for now