### PR TITLE
Allow admins to create journeys for any team

### DIFF
--- a/app/controllers/admin/journeys_controller.rb
+++ b/app/controllers/admin/journeys_controller.rb
@@ -2,15 +2,10 @@ class Admin::JourneysController < AdminController
   before_filter :find_journey, only: [:edit, :update, :destroy, :show, :send_message]
   before_filter :check_permissions, except: [:index, :create, :new, :show, :surrounding_journeys]
   def index
-    params[:filterrific] ||= {}
-    if current_supplier.admin?
-      journeys = Journey.all
-    else
-      journeys = params[:filter] == 'team' ? current_team.journeys : current_supplier.journeys
-    end
+    journeys = current_supplier.admin? ? Journey.all : current_team.journeys
     @filterrific = initialize_filterrific(
       journeys,
-      params[:filterrific]
+      (params[:filterrific] || {})
     ) or return
     @journeys = @filterrific.find.page(params[:page])
   end
@@ -18,7 +13,7 @@ class Admin::JourneysController < AdminController
   def new
     if params[:route_id]
       @route = Route.find(params[:route_id])
-      @journey = current_supplier.journeys.new(route: @route, reversed: params[:reversed])
+      @journey = current_team.journeys.new(route: @route, reversed: params[:reversed])
       @back_path = new_admin_journey_path
     else
       @back_path = admin_root_path
@@ -73,7 +68,7 @@ class Admin::JourneysController < AdminController
   private
 
   def journey_params
-    params.require(:journey).permit(:start_time, :supplier_id, :route_id, :open_to_bookings, :reversed, :seats)
+    params.require(:journey).permit(:start_time, :team_id, :route_id, :open_to_bookings, :reversed, :seats)
   end
 
   def find_journey

--- a/app/controllers/admin/timetables_controller.rb
+++ b/app/controllers/admin/timetables_controller.rb
@@ -29,7 +29,7 @@ class Admin::TimetablesController < AdminController
   def timetable_params
     params.require(:timetable).permit(
       :route_id,
-      :supplier_id,
+      :team_id,
       :from,
       :to,
       :open_to_bookings,

--- a/app/mailers/booking_mailer.rb
+++ b/app/mailers/booking_mailer.rb
@@ -5,12 +5,12 @@ class BookingMailer < ActionMailer::Base
 
   def booking_confirmed(params)
     @booking = Booking.find(params['booking_id'])
-    mail(to: @booking.journey.supplier.team.email, cc: ENV['RIDE_ADMIN_EMAIL'], subject: "A new booking has been confirmed (ref: #{@booking.booking_id})")
+    mail(to: @booking.journey.team.email, cc: ENV['RIDE_ADMIN_EMAIL'], subject: "A new booking has been confirmed (ref: #{@booking.booking_id})")
   end
   
   def booking_cancelled(params)
     @booking = Booking.find(params['booking_id'])
-    mail(to: @booking.journey.supplier.team.email, cc: ENV['RIDE_ADMIN_EMAIL'], subject: 'Booking cancelled')
+    mail(to: @booking.journey.team.email, cc: ENV['RIDE_ADMIN_EMAIL'], subject: 'Booking cancelled')
   end
   
   def user_confirmation(params)

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -35,7 +35,7 @@ class Booking < ActiveRecord::Base
   
   scope :state, ->(state) { where(state: state) }
   
-  scope :team, ->(team_id) { joins(journey: :supplier).where('suppliers.team_id = ?', team_id) }
+  scope :team, ->(team_id) { joins(:journey).where('team_id = ?', team_id) }
   
   filterrific(
     default_filter_params: { state: 'booked' },

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -6,8 +6,8 @@ class Journey < ActiveRecord::Base
   has_many :outward_bookings, dependent: :destroy, class_name: 'Booking', foreign_key: 'journey_id'
   has_many :return_bookings, dependent: :destroy, class_name: 'Booking', foreign_key: 'return_journey_id'
   has_many :bookings, dependent: :destroy, class_name: 'Booking'
-  belongs_to :supplier
-  validates_presence_of :supplier, :start_time, :route
+  belongs_to :team
+  validates_presence_of :team, :start_time, :route
   
   attr_accessor :pickup_stop, :dropoff_stop
 
@@ -77,7 +77,7 @@ class Journey < ActiveRecord::Base
   end
 
   def editable_by_supplier?(supplier)
-    supplier.team == self.supplier.team
+    supplier.team == self.team
   end
 
   def is_booked?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,6 +1,6 @@
 class Team < ActiveRecord::Base
   has_many :suppliers
-  has_many :journeys, through: :suppliers
+  has_many :journeys
   
   after_create :set_name
   

--- a/app/models/timetable.rb
+++ b/app/models/timetable.rb
@@ -1,6 +1,6 @@
 class Timetable < ActiveRecord::Base
   belongs_to :route
-  belongs_to :supplier
+  belongs_to :team
 
   has_many :timetable_times, dependent: :destroy
   has_many :journeys, through: :timetable_times

--- a/app/models/timetable_time.rb
+++ b/app/models/timetable_time.rb
@@ -21,7 +21,7 @@ class TimetableTime < ActiveRecord::Base
   def journey_params
     {
       seats: seats,
-      supplier: timetable.supplier,
+      team: timetable.team,
       route: get_route,
       open_to_bookings: timetable.open_to_bookings,
       reversed: timetable.reversed

--- a/app/services/sms_service.rb
+++ b/app/services/sms_service.rb
@@ -78,7 +78,7 @@ class SmsService
       I18n.t('sms.second_alert.body',
         pickup_name: @trip.pickup_name,
         pickup_time: plus_minus_ten(@trip.pickup_time),
-        supplier_number: @booking.journey.supplier.phone_number
+        supplier_number: @booking.journey.team.suppliers.first.phone_number
       ).squish
     end
     

--- a/app/views/admin/journeys/_fields.html.erb
+++ b/app/views/admin/journeys/_fields.html.erb
@@ -4,7 +4,13 @@
 
 <%= form.label :start_time, "Select Date & Time" %>
 <%= form.text_field :start_time, value: Time.now.strftime("%d/%m/%Y %H:%M") %>
-<%= form.hidden_field :team_id, value: current_supplier.team.id %>
+
+<% if current_supplier.admin? %>
+  <%= form.label :team_id, 'Team' %>
+  <%= form.select :team_id, options_from_collection_for_select(Team.all, 'id', 'name'), { selected: current_team.id }, class: 'select' %>
+<% else %>
+  <%= form.hidden_field :team_id, value: current_team.id %>
+<% end %>
 
 <%= form.label :seats, 'Number of available seats' %>
 <%= form.number_field :seats %>

--- a/app/views/admin/journeys/_fields.html.erb
+++ b/app/views/admin/journeys/_fields.html.erb
@@ -4,13 +4,7 @@
 
 <%= form.label :start_time, "Select Date & Time" %>
 <%= form.text_field :start_time, value: Time.now.strftime("%d/%m/%Y %H:%M") %>
-
-<% if current_team.solo_team? %>
-  <%= form.hidden_field :supplier_id, value: current_supplier.id %>
-<% else %>
-  <%= form.label :supplier_id, "Select Driver" %>
-  <%= form.select :supplier_id, current_supplier.team.suppliers.collect {|u| [u.name, u.id]} %>
-<% end %>
+<%= form.hidden_field :team_id, value: current_supplier.team.id %>
 
 <%= form.label :seats, 'Number of available seats' %>
 <%= form.number_field :seats %>

--- a/app/views/admin/journeys/index.html.erb
+++ b/app/views/admin/journeys/index.html.erb
@@ -76,13 +76,13 @@
     <% if @journeys.exists? %>
       <% @journeys.each do |journey| %>
         <%= link_to admin_journey_path(journey), class: "jrny-single" do %>
-          <div class="card<%= " past-journey" if journey.start_time.past? %><%= journey.supplier.name == @current_supplier.name ? " my-journey" : " team-journey" %>" id="jrny_<%= journey.id %>" data-booked="<% if journey.is_booked? %>true<% else %>false<% end %>">
+          <div class="card<%= " past-journey" if journey.start_time.past? %><%= journey.team == current_team ? " my-journey" : " team-journey" %>" id="jrny_<%= journey.id %>" data-booked="<% if journey.is_booked? %>true<% else %>false<% end %>">
             <div class="col-10 mobile-twoThird">
               <div class="inner">
                 <p><%= friendly_date journey.start_time %> <%= journey.start_time.strftime("%H:%M") %></p>
                 <p><%= journey.route.name %></p>
-                <% if journey.supplier.name != @current_supplier.name %>
-                  <p><strong>Driver:</strong> <%= journey.supplier.name %></p>
+                <% if journey.team != current_team %>
+                  <p><strong>Team:</strong> <%= journey.team.name %></p>
                 <% end %>
               </div>
             </div>

--- a/app/views/admin/journeys/show.html.erb
+++ b/app/views/admin/journeys/show.html.erb
@@ -4,9 +4,6 @@
       <div class="inner">
         <p><%= @journey.route.name %></p>
         <p>Date: <%= @journey.start_time.strftime("%F") %></p>
-        <% if !current_team.solo_team? %>
-          <p>Driver: <%= @journey.supplier.name %></p>
-        <% end %>
         <h3>Stops:</h3>
         <p><% @journey.stops.each do |stop| %></p>
           <p>

--- a/app/views/admin/timetables/_form.html.haml
+++ b/app/views/admin/timetables/_form.html.haml
@@ -1,9 +1,13 @@
 = form_for [:admin, timetable] do |form|
   
-  = form.hidden_field :team_id, value: current_team.id
-
   = form.label :route
   = form.select :route_id, options_from_collection_for_select(@routes, :id, :name, timetable.route_id), { include_blank: 'Please select a route' }, class: 'select'
+  
+  - if current_supplier.admin?
+    = form.label :team_id, 'Team'
+    = form.select :team_id, options_from_collection_for_select(Team.all, 'id', 'name'), { selected: current_team.id }, class: 'select'
+  - else
+    = form.hidden_field :team_id, value: current_team.id
   
   = form.label :from, 'Timetable Start Date'
   = form.date_select :from, { with_css_classes: true, order: [:day, :month, :year] }, { class: 'select' }

--- a/app/views/admin/timetables/_form.html.haml
+++ b/app/views/admin/timetables/_form.html.haml
@@ -1,13 +1,9 @@
 = form_for [:admin, timetable] do |form|
+  
+  = form.hidden_field :team_id, value: current_team.id
 
   = form.label :route
   = form.select :route_id, options_from_collection_for_select(@routes, :id, :name, timetable.route_id), { include_blank: 'Please select a route' }, class: 'select'
-  
-  - if current_team.solo_team?
-    = form.hidden_field :supplier_id, value: current_supplier.id
-  - else
-    = form.label :supplier_id, 'Driver'
-    = form.select :supplier_id, options_from_collection_for_select(current_supplier.team.suppliers, :id, :name, timetable.supplier_id), {}, class: 'select'
   
   = form.label :from, 'Timetable Start Date'
   = form.date_select :from, { with_css_classes: true, order: [:day, :month, :year] }, { class: 'select' }

--- a/db/migrate/20180131132916_replace_supplier_reference_with_team_on_journeys.rb
+++ b/db/migrate/20180131132916_replace_supplier_reference_with_team_on_journeys.rb
@@ -1,0 +1,11 @@
+class ReplaceSupplierReferenceWithTeamOnJourneys < ActiveRecord::Migration
+  def change
+    add_reference :journeys, :team
+    Journey.all.each do |j|
+      supplier = ActiveRecord::Base.connection.execute("SELECT * FROM suppliers where id=#{j.supplier_id}").first
+      j.team_id = supplier['team_id']
+      j.save
+    end
+    remove_column :journeys, :supplier_id
+  end
+end

--- a/db/migrate/20180131133457_replace_supplier_reference_with_team_in_timetable.rb
+++ b/db/migrate/20180131133457_replace_supplier_reference_with_team_in_timetable.rb
@@ -1,0 +1,11 @@
+class ReplaceSupplierReferenceWithTeamInTimetable < ActiveRecord::Migration
+  def change
+    add_reference :timetables, :team
+    Timetable.all.each do |t|
+      supplier = ActiveRecord::Base.connection.execute("SELECT * FROM suppliers where id=#{j.supplier_id}").first
+      t.team_id = supplier['team_id']
+      t.save
+    end
+    remove_column :timetables, :supplier_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180131125316) do
+ActiveRecord::Schema.define(version: 20180131133457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,16 +70,15 @@ ActiveRecord::Schema.define(version: 20180131125316) do
     t.datetime "start_time"
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
-    t.integer  "supplier_id"
     t.boolean  "open_to_bookings",  default: true
     t.boolean  "reversed"
     t.boolean  "booked",            default: false
     t.integer  "seats",             default: 0
     t.integer  "timetable_time_id"
+    t.integer  "team_id"
   end
 
   add_index "journeys", ["route_id"], name: "index_journeys_on_route_id", using: :btree
-  add_index "journeys", ["supplier_id"], name: "index_journeys_on_supplier_id", using: :btree
   add_index "journeys", ["timetable_time_id"], name: "index_journeys_on_timetable_time_id", using: :btree
 
   create_table "landmarks", force: :cascade do |t|
@@ -254,12 +253,12 @@ ActiveRecord::Schema.define(version: 20180131125316) do
     t.date     "from"
     t.date     "to"
     t.integer  "route_id"
-    t.integer  "supplier_id"
     t.boolean  "reversed",         default: false
     t.boolean  "open_to_bookings", default: true
     t.json     "days",             default: [0, 1, 2, 3, 4, 5, 6]
     t.datetime "created_at",                                       null: false
     t.datetime "updated_at",                                       null: false
+    t.integer  "team_id"
   end
 
   add_foreign_key "bookings", "journeys"
@@ -268,7 +267,6 @@ ActiveRecord::Schema.define(version: 20180131125316) do
   add_foreign_key "bookings", "stops", column: "dropoff_stop_id"
   add_foreign_key "bookings", "stops", column: "pickup_stop_id"
   add_foreign_key "journeys", "routes"
-  add_foreign_key "journeys", "suppliers"
   add_foreign_key "landmarks", "stops"
   add_foreign_key "stops", "places"
   add_foreign_key "stops", "routes"

--- a/spec/controllers/admin/bookings_controller_spec.rb
+++ b/spec/controllers/admin/bookings_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Admin::BookingsController, type: :controller do
 
         get :index, filterrific: { route: route.id, state: 'booked' }
         
-        expect(assigns(:bookings)).to eq([booked_bookings[0], booked_bookings[1]])
+        expect(assigns(:bookings)).to match_array([booked_bookings[0], booked_bookings[1]])
       end
       
       it 'by date from' do
@@ -66,7 +66,7 @@ RSpec.describe Admin::BookingsController, type: :controller do
 
         get :index, filterrific: { date_from: Date.today + 2.days, state: 'booked' }
 
-        expect(assigns(:bookings)).to eq([booked_bookings[3], booked_bookings[4]])
+        expect(assigns(:bookings)).to match_array([booked_bookings[3], booked_bookings[4]])
       end
       
       it 'by date to' do
@@ -76,7 +76,7 @@ RSpec.describe Admin::BookingsController, type: :controller do
 
         get :index, filterrific: { date_to: Date.today - 2.days, state: 'booked' }
 
-        expect(assigns(:bookings)).to eq([booked_bookings[3], booked_bookings[4]])
+        expect(assigns(:bookings)).to match_array([booked_bookings[3], booked_bookings[4]])
       end
       
       it 'by state' do
@@ -85,12 +85,12 @@ RSpec.describe Admin::BookingsController, type: :controller do
       end
       
       it 'by team' do
-        supplier = FactoryBot.create(:supplier)
-        journey = FactoryBot.create(:journey, supplier: supplier)
+        team = FactoryBot.create(:team)
+        journey = FactoryBot.create(:journey, team: team)
         booked_bookings[4].update_attributes(journey: journey)
         
-        get :index, filterrific: { team: supplier.team }
-        expect(assigns(:bookings)).to eq([ booked_bookings[4] ])
+        get :index, filterrific: { team: team }
+        expect(assigns(:bookings)).to match_array([ booked_bookings[4] ])
       end
       
     end

--- a/spec/controllers/admin/teams_controller_spec.rb
+++ b/spec/controllers/admin/teams_controller_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe Admin::TeamsController, type: :controller do
   login_supplier(true)
   
-  let(:team) { FactoryBot.create(:team) }
+  let(:team) { FactoryBot.create(:team, suppliers: []) }
 
   describe 'GET index' do
     
-    let(:teams) { FactoryBot.create_list(:team, 5) }
+    let(:teams) { FactoryBot.create_list(:team, 5, suppliers: []) }
     
     it 'gets all teams' do
       get :index

--- a/spec/controllers/admin/timetables_controller_spec.rb
+++ b/spec/controllers/admin/timetables_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Admin::TimetablesController, type: :controller do
   login_supplier(true)
   
   let(:route) { FactoryBot.create(:route, stops_count: 5) }
-  let(:supplier) { FactoryBot.create(:supplier) }
+  let(:team) { FactoryBot.create(:team) }
 
   describe '#create' do
     
@@ -13,7 +13,7 @@ RSpec.describe Admin::TimetablesController, type: :controller do
         timetable: {
           from: DateTime.now,
           to: DateTime.now + 3.days,
-          supplier_id: supplier.id,
+          team_id: team.id,
           route_id: route.id,
           open_to_bookings: false,
           reversed: true,
@@ -63,7 +63,7 @@ RSpec.describe Admin::TimetablesController, type: :controller do
           timetable: {
             from: Date.parse('2016-01-03'),
             to: Date.parse('2016-01-10'),
-            supplier_id: supplier.id,
+            team_id: team.id,
             route_id: route.id,
             open_to_bookings: false,
             reversed: true,
@@ -95,7 +95,7 @@ RSpec.describe Admin::TimetablesController, type: :controller do
           timetable: {
             from: Date.parse('2016-01-03'),
             to: Date.parse('2016-01-10'),
-            supplier_id: supplier.id,
+            team_id: team.id,
             route_id: route.id,
             open_to_bookings: false,
             reversed: true,

--- a/spec/controllers/suppliers/journeys_controller_spec.rb
+++ b/spec/controllers/suppliers/journeys_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Admin::JourneysController, type: :controller do
   
   let(:journey) do
     FactoryBot.create(:journey,
-      supplier: @supplier,
+      team: @supplier.team,
       outward_bookings: FactoryBot.create_list(:booking, 5)
     )
   end
@@ -17,18 +17,12 @@ RSpec.describe Admin::JourneysController, type: :controller do
       
       before do
         FactoryBot.create_list(:journey, 2)
-        FactoryBot.create_list(:journey, 3, supplier: @supplier)
-        FactoryBot.create_list(:journey, 5, supplier: FactoryBot.create(:supplier, team: @supplier.team))
-      end
-      
-      it 'gets all journeys for a supplier' do
-        get :index
-        expect(assigns(:journeys).count).to eq(3)
+        FactoryBot.create_list(:journey, 3, team: @supplier.team)
       end
       
       it 'gets all journeys for a team' do
         get :index, { filter: 'team' }
-        expect(assigns(:journeys).count).to eq(8)
+        expect(assigns(:journeys).count).to eq(3)
       end
       
       context 'as an admin' do
@@ -36,7 +30,7 @@ RSpec.describe Admin::JourneysController, type: :controller do
 
         it 'gets all journeys for an admin' do
           get :index
-          expect(assigns(:journeys).count).to eq(10)
+          expect(assigns(:journeys).count).to eq(5)
         end
       end
       
@@ -44,8 +38,8 @@ RSpec.describe Admin::JourneysController, type: :controller do
 
     context 'filtering' do
       it 'filters by past or future' do
-        FactoryBot.create_list(:journey, 2, start_time: DateTime.now - 4.days, supplier: @supplier)
-        FactoryBot.create_list(:journey, 3, start_time: DateTime.now + 4.days, supplier: @supplier)
+        FactoryBot.create_list(:journey, 2, start_time: DateTime.now - 4.days, team: @supplier.team)
+        FactoryBot.create_list(:journey, 3, start_time: DateTime.now + 4.days, team: @supplier.team)
         get :index, { filterrific: {
             past_or_future: 'future'
           }
@@ -59,9 +53,9 @@ RSpec.describe Admin::JourneysController, type: :controller do
       end
       
       it 'filters by booked and empty' do
-        FactoryBot.create_list(:journey, 2, outward_bookings: FactoryBot.create_list(:booking, 4), supplier: @supplier, booked: true)
-        FactoryBot.create_list(:journey, 5, return_bookings: FactoryBot.create_list(:booking, 2), supplier: @supplier, booked: true)
-        FactoryBot.create_list(:journey, 3, supplier: @supplier, booked: false)
+        FactoryBot.create_list(:journey, 2, outward_bookings: FactoryBot.create_list(:booking, 4), team: @supplier.team, booked: true)
+        FactoryBot.create_list(:journey, 5, return_bookings: FactoryBot.create_list(:booking, 2), team: @supplier.team, booked: true)
+        FactoryBot.create_list(:journey, 3, team: @supplier.team, booked: false)
         get :index, { filterrific: {
             booked_or_empty: 'booked'
           }
@@ -90,7 +84,7 @@ RSpec.describe Admin::JourneysController, type: :controller do
       expect(assigns(:route)).to eq(route)
       journey = assigns(:journey)
       expect(journey.route).to eq(route)
-      expect(journey.supplier).to eq(@supplier)
+      expect(journey.team).to eq(@supplier.team)
       expect(journey.reversed).to eq(false)
     end
 
@@ -104,7 +98,7 @@ RSpec.describe Admin::JourneysController, type: :controller do
         journey: {
           start_time: start_time,
           seats: 4,
-          supplier_id: @supplier.id,
+          team_id: @supplier.team.id,
           route_id: route.id,
           open_to_bookings: true,
           reversed: true
@@ -114,7 +108,7 @@ RSpec.describe Admin::JourneysController, type: :controller do
       journey = Journey.last
       expect(journey.start_time.to_i).to eq(start_time.to_i)
       expect(journey.seats).to eq(4)
-      expect(journey.supplier).to eq(@supplier)
+      expect(journey.team).to eq(@supplier.team)
       expect(journey.route).to eq(route)
       expect(journey.open_to_bookings).to eq(true)
       expect(journey.reversed).to eq(true)
@@ -163,7 +157,7 @@ RSpec.describe Admin::JourneysController, type: :controller do
   context '#destroy' do
     
     it 'destroys a journey' do
-      journey = FactoryBot.create(:journey, supplier: @supplier)
+      journey = FactoryBot.create(:journey, team: @supplier.team)
       expect {
         delete :destroy, { id: journey.id }
       }.to change(Journey, :count).by(-1)

--- a/spec/factories/booking.rb
+++ b/spec/factories/booking.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory(:booking) do
     dropoff_stop factory: :stop
-    journey { FactoryBot.create(:journey, supplier: supplier) }
+    journey { FactoryBot.create(:journey, team: team) }
     passenger
     phone_number nil
     pickup_stop factory: :stop
@@ -14,11 +14,11 @@ FactoryBot.define do
     end
     
     transient do
-      supplier { FactoryBot.create(:supplier) }
+      team { FactoryBot.create(:team) }
     end
     
     trait(:with_return_journey) do
-      return_journey { FactoryBot.create(:journey, supplier: supplier) }
+      return_journey { FactoryBot.create(:journey, team: team) }
     end
   end
 end

--- a/spec/factories/journey.rb
+++ b/spec/factories/journey.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     open_to_bookings true
     route
     sequence(:start_time) { |n| Date.tomorrow + n.hours  }
-    supplier { FactoryBot.create(:supplier) }
+    team { FactoryBot.create(:team) }
     seats 5
   end
 end

--- a/spec/factories/team.rb
+++ b/spec/factories/team.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory(:team) do
     name nil
     email 'hello@example.com'
+    suppliers { FactoryBot.create_list(:supplier, 2) }
   end
 end

--- a/spec/factories/timetable.rb
+++ b/spec/factories/timetable.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory(:timetable) do
-    supplier { FactoryBot.create(:supplier) }
+    team { FactoryBot.create(:team) }
     route { FactoryBot.create(:route) }
   end
 end

--- a/spec/mailers/booking_mailer_spec.rb
+++ b/spec/mailers/booking_mailer_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe BookingMailer, type: :mailer do
   }
   let(:route) { FactoryBot.create(:route, stops: stops) }
   let(:team) { FactoryBot.create(:team, email: 'team@example.com') }
-  let(:supplier) { FactoryBot.create(:supplier, team: team) }
-  let(:journey) { FactoryBot.create(:journey, route: route, start_time: DateTime.parse('2017-01-01T10:00:00'), supplier: supplier) }
+  let(:journey) { FactoryBot.create(:journey, route: route, start_time: DateTime.parse('2017-01-01T10:00:00'), team: team) }
   let(:booking) {
     FactoryBot.create(:booking,
       journey: journey,

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -138,13 +138,13 @@ RSpec.describe Journey, type: :model do
   
   context '#duplicate' do
     
-    let(:supplier) { FactoryBot.create(:supplier) }
+    let(:team) { FactoryBot.create(:team) }
     let(:route) { FactoryBot.create(:route) }
     let(:journey) {
       FactoryBot.create(:journey,
         start_time: '2016-01-01T09:00:00Z',
         seats: 5,
-        supplier: supplier,
+        team: team,
         open_to_bookings: true,
         reversed: false,
         route: route
@@ -157,7 +157,7 @@ RSpec.describe Journey, type: :model do
       (Date.parse('2016-01-02')..Date.parse('2016-01-10')).each_with_index do |d,i|
         j = Journey.all.to_a[i + 1]
         expect(j.seats).to eq(5)
-        expect(j.supplier).to eq(supplier)
+        expect(j.team).to eq(team)
         expect(j.route).to eq(route)
         expect(j.start_time.to_date).to eq(d)
         expect(j.start_time.hour).to eq(9)


### PR DESCRIPTION
This removes the direct relation between Suppliers and Journeys and allows Teams to be applied directly to journeys instead. Admins can then create journeys for any Team.