### PR TITLE
Booking improvements

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -8,6 +8,7 @@ class BookingsController < PublicController
     @to = Place.friendly.find(params[:to])
     @journeys = get_journeys
     @booking = Booking.new
+    @booking.passenger = Passenger.new
   end
 
   # Save stops
@@ -105,8 +106,6 @@ class BookingsController < PublicController
       :dropoff_stop_id,
       :dropoff_landmark_id,
       :passenger_phone_number,
-      :passenger_email,
-      :passenger_name,
       :payment_method,
       :number_of_passengers,
       :special_requirements,
@@ -118,7 +117,8 @@ class BookingsController < PublicController
       :verification_code,
       :cancellation_reason,
       :state,
-      :missed_feedback
+      :missed_feedback,
+      passenger_attributes: [:phone_number, :email, :name]
     )
   end
 

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -33,7 +33,7 @@ class BookingsController < PublicController
       begin
         @booking.create_payment!(params[:stripe_token]) if params[:stripe_token].present?
         @booking.confirm!
-        redirect_to confirmation_booking_path(@booking)
+        redirect_to confirmation_bookings_path
       rescue Stripe::CardError => e
         flash[:alert] = "There was a problem with your card. The message from the provider was: '#{e.message}'"
         render :summary
@@ -129,6 +129,8 @@ class BookingsController < PublicController
   def find_booking
     @booking = if params[:token]
       Booking.find_by_token(params[:token])
+    elsif session[:booking_id]
+      Booking.find(session[:booking_id])
     else
       Booking.find(params[:id])
     end

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -14,6 +14,7 @@ class BookingsController < PublicController
   def create
     @booking = Booking.create(booking_params)
     if @booking.valid?
+      session[:booking_id] = @booking.id
       render :summary
     else
       render :edit

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -14,7 +14,7 @@ class Booking < ApplicationRecord
   
   delegate :email, :phone_number, :name, to: :passenger
   
-  after_create :generate_passenger
+  accepts_nested_attributes_for :passenger
 
   scope :booked, -> { where(state: ['booked', 'successful', 'missed']) }
   
@@ -306,21 +306,6 @@ class Booking < ApplicationRecord
         random_token = SecureRandom.urlsafe_base64(nil, false)
         break random_token unless Booking.exists?(token: random_token)
       end
-    end
-    
-    def generate_passenger
-      return unless passenger.nil?
-      passenger = setup_passenger(passenger_phone_number, passenger_email, passenger_name)
-      update_attribute(:passenger_id, passenger.id)
-    end
-    
-    def setup_passenger(phone_number, email, name)
-      phone_number = PhoneNumberFormatter.new(phone_number).format
-      Passenger.find_or_create_by(
-        phone_number: phone_number,
-        email: email,
-        name: name
-      )
     end
   
 end

--- a/app/models/passenger.rb
+++ b/app/models/passenger.rb
@@ -4,6 +4,8 @@ class Passenger < ApplicationRecord
   has_many :suggested_journeys, dependent: :destroy
   has_many :suggested_edit_to_stops, dependent: :destroy
   has_many :suggested_routes, dependent: :destroy
+  
+  before_save :format_phone_number, if: :phone_number_changed?
 
   has_attached_file :photo, styles: {
     thumb: '100x100>',
@@ -16,5 +18,11 @@ class Passenger < ApplicationRecord
   def anonymise!
     update_attributes(name: nil, email: nil, phone_number: nil)
     save
+  end
+  
+  private
+    
+  def format_phone_number
+    self.phone_number = PhoneNumberFormatter.new(phone_number).format unless phone_number.nil?
   end
 end

--- a/app/views/bookings/_form.html.haml
+++ b/app/views/bookings/_form.html.haml
@@ -59,27 +59,29 @@
           %span.required
             *
           = t('form.required')
+        
+        = form.fields_for :passenger do |f|
           
-        = form.label :passenger_name, :class => 'long' do
-          = t('bookings.lead.label')
-          %span.required
-            *
-        = form.text_field :passenger_name, required: true
-    
-        = form.label :passenger_phone_number, :class => 'long' do
-          = t('bookings.lead.mobile.label')
-          %span.required
-            *
-          %span.small
-            = t('bookings.lead.mobile.message')
-        = form.text_field :passenger_phone_number, required: true, pattern: '.{11,}', minlength: 11, title: 'Minimum of 11 characters'
-    
-    
-        = form.label :passenger_email, :class => 'long' do
-          = t('bookings.lead.email.label')
-          %spans.small
-            = t('bookings.lead.email.message')
-        = form.text_field :passenger_email
+          = f.label :name, :class => 'long' do
+            = t('bookings.lead.label')
+            %span.required
+              *
+          = f.text_field :name, required: true
+      
+          = f.label :phone_number, :class => 'long' do
+            = t('bookings.lead.mobile.label')
+            %span.required
+              *
+            %span.small
+              = t('bookings.lead.mobile.message')
+          = f.text_field :phone_number, required: true, pattern: '.{11,}', minlength: 11, title: 'Minimum of 11 characters'
+      
+      
+          = f.label :email, :class => 'long' do
+            = t('bookings.lead.email.label')
+            %spans.small
+              = t('bookings.lead.email.message')
+          = f.text_field :email
     
       = form.submit :class => 'button cta primary', :id => 'submit-booking', value: t('button.next')
 

--- a/app/views/bookings/_form.html.haml
+++ b/app/views/bookings/_form.html.haml
@@ -19,7 +19,7 @@
           %label
             = to.name
 
-  = form_for @booking do |form|
+  = form_for @booking, form_params do |form|
   
     = form.hidden_field :pickup_stop_id
     = form.hidden_field :dropoff_stop_id

--- a/app/views/bookings/edit.html.haml
+++ b/app/views/bookings/edit.html.haml
@@ -1,1 +1,1 @@
-= render 'form', from: @from, to: @to
+= render 'form', from: @from, to: @to, form_params: { url: bookings_path, method: :put }

--- a/app/views/bookings/new.html.haml
+++ b/app/views/bookings/new.html.haml
@@ -1,1 +1,1 @@
-= render 'form', from: @from, to: @to
+= render 'form', from: @from, to: @to, form_params: {}

--- a/app/views/bookings/summary.html.haml
+++ b/app/views/bookings/summary.html.haml
@@ -1,5 +1,5 @@
 - content_for :top_sec do
-  = form_for @booking do |form|
+  = form_for @booking, url: bookings_path, method: :put do |form|
     
     = hidden_field_tag :stripe_token
     
@@ -150,7 +150,7 @@
             = map(@booking.pickup_landmark.latitude, @booking.pickup_landmark.longitude)
     %section.section
       %p
-        = link_to edit_booking_path(@booking) do
+        = link_to edit_bookings_path do
           = t('summary.back')
 
     %section.section

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,11 @@ Rails.application.routes.draw do
     collection do
       post :price
       post :passengers
+      get :confirmation
+      get :edit
+      put :update
     end
     member do
-      get :confirmation
       get :return_journeys
       put :send_missed_feedback
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
       get ':from/:to/return' => 'journeys#return', as: :return
     end
   end
-  resources :bookings do
+  resources :bookings, only: [:new, :create, :destroy] do
     collection do
       post :price
       post :passengers

--- a/spec/controllers/bookings_controller_spec.rb
+++ b/spec/controllers/bookings_controller_spec.rb
@@ -47,9 +47,11 @@ RSpec.describe BookingsController, type: :controller do
         booking: {
           pickup_stop_id: route.stops.first.id,
           dropoff_stop_id: route.stops.last.id,
-          passenger_name: 'Me',
-          passenger_phone_number: '+441473760072',
-          passenger_email: 'email@example.com',
+          passenger_attributes: {
+            name: 'Me',
+            phone_number: '+441473760072',
+            email: 'email@example.com'
+          }
         }
       }
     }
@@ -65,9 +67,9 @@ RSpec.describe BookingsController, type: :controller do
     
     it 'creates a passenger' do
       expect(booking.passenger).to_not eq(nil)
-      expect(booking.passenger.name).to eq(params[:booking][:passenger_name])
-      expect(booking.passenger.email).to eq(params[:booking][:passenger_email])
-      expect(booking.passenger.phone_number).to eq(params[:booking][:passenger_phone_number])
+      expect(booking.passenger.name).to eq(params[:booking][:passenger_attributes][:name])
+      expect(booking.passenger.email).to eq(params[:booking][:passenger_attributes][:email])
+      expect(booking.passenger.phone_number).to eq(params[:booking][:passenger_attributes][:phone_number])
     end
     
   end

--- a/spec/features/booking.feature
+++ b/spec/features/booking.feature
@@ -58,3 +58,11 @@ Feature: Booking a journey
     Then my booking should be confirmed
     And my booking should have 2 passengers
     And my booking should have 1 child ticket
+    
+  Scenario: Change booking details
+    Given I have chosen a single journey
+    And I fill in my details
+    And I edit my booking's contact details
+    And I confirm my booking
+    Then my booking should be confirmed
+    And my contact details should be saved

--- a/spec/features/steps/web_steps.rb
+++ b/spec/features/steps/web_steps.rb
@@ -11,6 +11,13 @@ module WebSteps
   step :choose_journey, 'I choose a journey'
   step :choose_pickup_and_dropoff_point, 'I choose a pickup and dropoff point'
   
+  step 'I edit my booking\'s contact details' do
+    click_on I18n.t('summary.back')
+    choose_journey
+    choose_pickup_and_dropoff_point
+    fill_in_details('New Name', '+15005550006')
+  end
+  
   step 'I have entered my booking details' do
     choose_place('from', 'Newmarket')
     choose_place('to', 'Haverhill')
@@ -190,9 +197,9 @@ module WebSteps
     @first_name = first_name
     @phone_number = phone_number
     @email = email
-    fill_in 'booking_passenger_name', with: first_name
-    fill_in 'booking_passenger_phone_number', with: phone_number
-    fill_in 'booking_passenger_email', with: email
+    fill_in 'booking[passenger_attributes][name]', with: first_name
+    fill_in 'booking[passenger_attributes][phone_number]', with: phone_number
+    fill_in 'booking[passenger_attributes][email]', with: email
     page.execute_script 'document.getElementById(\'submit-booking\').scrollIntoView(true)'
     click_button I18n.t('button.next')
   end

--- a/spec/fixtures/cassettes/TriggerSurvey/deletes_itself_if_the_booking_does_not_exist.yml
+++ b/spec/fixtures/cassettes/TriggerSurvey/deletes_itself_if_the_booking_does_not_exist.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://lookups.twilio.com/v1/PhoneNumbers/01632960373?CountryCode=GB
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - twilio-ruby/5.11.1 (ruby/x86_64-darwin16 2.3.4-p301)
+      Accept-Charset:
+      - utf-8
+      Accept:
+      - application/json
+      Authorization:
+      - Basic <ENCODED AUTH HEADER>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match,
+        If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - ETag
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 25 Jul 2018 09:38:53 GMT
+      Twilio-Request-Duration:
+      - '0.012'
+      Twilio-Request-Id:
+      - RQ56fe356d815441c5b87e80a2b5427a84
+      X-Powered-By:
+      - AT-5000
+      X-Shenanigans:
+      - none
+      Content-Length:
+      - '164'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"code": 20404, "message": "The requested resource /PhoneNumbers/01632960373
+        was not found", "more_info": "https://www.twilio.com/docs/errors/20404", "status":
+        404}'
+    http_version: 
+  recorded_at: Wed, 25 Jul 2018 09:38:53 GMT
+recorded_with: VCR 4.0.0

--- a/spec/jobs/trigger_survey_spec.rb
+++ b/spec/jobs/trigger_survey_spec.rb
@@ -3,6 +3,9 @@ require 'support/vcr'
 
 RSpec.describe TriggerSurvey, :vcr, :webmock do
   
+  before(:all) { Passenger.skip_callback(:save, :before, :format_phone_number) }
+  after(:all) { Passenger.set_callback(:save, :before, :format_phone_number, if: :phone_number_changed?) }
+
   let(:booking) { FactoryBot.create(:booking, phone_number: '+15005550006') }
   let(:client) { Twilio::REST::Client.new }
   

--- a/spec/models/passenger_spec.rb
+++ b/spec/models/passenger_spec.rb
@@ -12,4 +12,27 @@ RSpec.describe Passenger, type: :model do
     expect(passenger.phone_number).to eq(nil)
   end
   
+  context '#format_phone_number' do
+    
+    it 'formats on create' do
+      passenger = FactoryBot.build(:passenger, phone_number: '01473760072')
+      passenger.save
+      passenger.reload
+      expect(passenger.phone_number).to eq('+441473760072')
+    end
+    
+    it 'formats on update' do
+      passenger.phone_number = '01473760072'
+      passenger.save
+      passenger.reload
+      expect(passenger.phone_number).to eq('+441473760072')
+    end
+    
+    it 'ignores the formatter if phone number has not changed' do
+      expect(passenger).to_not receive(:format_phone_number)
+      passenger.save
+    end
+    
+  end
+  
 end


### PR DESCRIPTION
Previously, anyone could alter someone else's booking by guessing the ID. This now adds the booking ID to the user's session, so bookings can't be edited / viewed by guessing the URL.

I've also cleaned up the creation / editing of Passengers by using `accepts_nested_attributes_for` (as it should be), rather than callbacks.